### PR TITLE
Support Docutils 0.22

### DIFF
--- a/sphinx_sizzle_theme/__init__.py
+++ b/sphinx_sizzle_theme/__init__.py
@@ -25,7 +25,7 @@ except ImportError:
     from urllib2 import urlopen, Request
 
 from docutils.nodes import (strong, emphasis, inline, Text, document,
-                            paragraph, reprunicode, raw, literal)
+                            paragraph, raw, literal)
 
 from docutils.parsers.rst.roles import set_classes
 


### PR DESCRIPTION
``nodes.reprunicode`` was removed in Docutils 0.22. It is unused by the theme.

A